### PR TITLE
Add Alternatives section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ somePromise
 	.then(() => ({result: Nothing}))
 	.then((result) => result) // promise resolves
 ```
+## Alternatives
+### Lodash
+Lodash has a `_.get` operator which takes an array `_.get(context, ['namespace', 'actions', 'someAction'])` or string `_.get(context, 'namespace.actions.someAction')` and returns `null` if one of the properties doesn't exist. You can see the documentation [here](https://lodash.com/docs/#get).
 
 ## License
 MIT


### PR DESCRIPTION
I really like the concept and love when a language [1](http://docs.groovy-lang.org/latest/html/documentation/index.html#_safe_navigation_operator), [2](https://kotlinlang.org/docs/reference/null-safety.html#safe-calls) implements this as a feature.

However, Javascript doesn't support this by default and it may not be convenient to use this library since it's a workaround and really hard to find out what's going on in case there is a bug in our code. (If you don't know what `context` is, the behavior of `context.namespace.actions.someAction()` is unknown and since JS doesn't have type safety it's hard to pinpoint it using an IDE)

Therefore, I believe that it's a good practice to add alternatives to this library even though they don't cover the same feature-set.